### PR TITLE
[WIP] Remove macos target for builds and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,10 @@ jobs:
 
   test:
     name: Test Suite
+    if: ${{ !startsWith(github.event.pull_request.title, '[WIP]') }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest] # macos-latest might be readded later
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Skip builds and tests if the PR name starts with `[WIP]`.
Removed `macos-latest` from action target matrix.